### PR TITLE
Persist segment edits and sync palette on scene change

### DIFF
--- a/src/components/panel/segment_edit_action.py
+++ b/src/components/panel/segment_edit_action.py
@@ -16,39 +16,77 @@ class SegmentEditActionHandler:
         
     def update_segment_color_slot(self, segment_id: str, color_index: int, selected_color_index: int):
         """Update segment color slot parameter"""
-        if self.validate_color_indices(color_index, selected_color_index):
-            self.toast_manager.show_success_sync(f"Segment {segment_id} color slot {color_index} updated")
+        if not self.validate_color_indices(color_index, selected_color_index):
+            return False
+
+        # Update cache via color service so changes persist when switching segments
+        success = color_service.update_segment_color_slot(
+            segment_id, color_index, selected_color_index
+        )
+        if success:
+            self.toast_manager.show_success_sync(
+                f"Segment {segment_id} color slot {color_index} updated"
+            )
             return True
+
+        self.toast_manager.show_error_sync(
+            f"Failed to update color slot {color_index} for segment {segment_id}"
+        )
         return False
         
     def update_transparency_from_field(self, index: int, value: str, segment_component):
         """Handle transparency field change"""
         try:
             transparency = float(value)
-            if self.validate_transparency_value(transparency):
-                segment_id = segment_component.get_selected_segment()
-                self.toast_manager.show_info_sync(f"Segment {segment_id} transparency {index} updated to {transparency}")
+            if not self.validate_transparency_value(transparency):
+                return None
+
+            segment_id = segment_component.get_selected_segment()
+            if color_service.update_segment_transparency(segment_id, index, transparency):
+                self.toast_manager.show_info_sync(
+                    f"Segment {segment_id} transparency {index} updated to {transparency}"
+                )
                 return transparency
+            self.toast_manager.show_error_sync(
+                f"Failed to update transparency {index} for segment {segment_id}"
+            )
         except ValueError:
             self.toast_manager.show_error_sync("Invalid transparency value")
         return None
-            
+
     def update_transparency_from_slider(self, index: int, value: float, segment_component):
         """Handle transparency slider change"""
-        if self.validate_transparency_value(value):
-            segment_id = segment_component.get_selected_segment()
-            self.toast_manager.show_info_sync(f"Segment {segment_id} transparency {index} updated to {value:.2f}")
+        if not self.validate_transparency_value(value):
+            return None
+
+        segment_id = segment_component.get_selected_segment()
+        if color_service.update_segment_transparency(segment_id, index, value):
+            self.toast_manager.show_info_sync(
+                f"Segment {segment_id} transparency {index} updated to {value:.2f}"
+            )
             return value
+
+        self.toast_manager.show_error_sync(
+            f"Failed to update transparency {index} for segment {segment_id}"
+        )
         return None
             
     def update_length_parameter(self, index: int, value: str, segment_component):
         """Handle length change"""
         try:
             length = int(value)
-            if self.validate_length_value(length):
-                segment_id = segment_component.get_selected_segment()
-                self.toast_manager.show_success_sync(f"Segment {segment_id} length {index} updated to {length}")
+            if not self.validate_length_value(length):
+                return None
+
+            segment_id = segment_component.get_selected_segment()
+            if color_service.update_segment_length(segment_id, index, length):
+                self.toast_manager.show_success_sync(
+                    f"Segment {segment_id} length {index} updated to {length}"
+                )
                 return length
+            self.toast_manager.show_error_sync(
+                f"Failed to update length {index} for segment {segment_id}"
+            )
         except ValueError:
             self.toast_manager.show_error_sync("Invalid length value")
         return None

--- a/tests/test_scene_palette_sync.py
+++ b/tests/test_scene_palette_sync.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from components.scene.scene_action import SceneActionHandler
+from services.color_service import color_service
+from services.data_cache import data_cache
+
+
+def test_palette_sync_after_scene_creation():
+    handler = SceneActionHandler(page=None)
+
+    # Change current palette color to a custom value to detect reset
+    color_service.update_palette_color(0, "#ABCDEF")
+    assert color_service.get_palette_colors()[0] == "#ABCDEF"
+
+    # Add new scene which becomes current
+    handler.add_scene(None)
+
+    # After new scene, palette should sync with cache default (first color red)
+    assert color_service.get_palette_colors()[0] == "#FF0000"

--- a/tests/test_segment_persistence.py
+++ b/tests/test_segment_persistence.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from components.panel.segment_edit_action import SegmentEditActionHandler
+from services.color_service import color_service
+from services.data_cache import data_cache
+
+
+class StubSegmentComponent:
+    def __init__(self, segment_id: str):
+        self._segment_id = segment_id
+
+    def get_selected_segment(self):
+        return self._segment_id
+
+
+def test_segment_updates_persist_across_switch():
+    handler = SegmentEditActionHandler(page=None)
+
+    # Reset to initial scene with default segment
+    data_cache.set_current_scene(0)
+    color_service.sync_with_cache_palette()
+    color_service.set_current_segment_id("0")
+
+    # Ensure second segment exists
+    data_cache.create_new_segment(custom_id=1)
+
+    # Update values for segment 0
+    handler.update_segment_color_slot("0", 0, 3)
+    handler.update_transparency_from_slider(0, 0.5, StubSegmentComponent("0"))
+    handler.update_length_parameter(0, "20", StubSegmentComponent("0"))
+
+    # Switch to another segment then back
+    color_service.set_current_segment_id("1")
+    color_service.set_current_segment_id("0")
+
+    seg0 = data_cache.get_segment("0")
+    assert seg0.color[0] == 3
+    assert seg0.transparency[0] == 0.5
+    assert seg0.length[0] == 20


### PR DESCRIPTION
## Summary
- ensure segment color, transparency and length edits persist by updating the cache via `ColorService`
- sync color palette and segment context whenever scenes change so new scenes show correct colors
- add tests for segment persistence and palette sync

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac371d3414832a920c37a0303580da