### PR TITLE
Fix scene and segment handling for LED app

### DIFF
--- a/src/services/data_cache.py
+++ b/src/services/data_cache.py
@@ -411,11 +411,28 @@ class DataCacheService:
         new_id = max(self.scenes.keys()) + 1 if self.scenes else 0
         
         default_palette = [
-            [255, 0, 0], [0, 255, 0], [0, 0, 255],
-            [255, 255, 0], [255, 0, 255], [0, 255, 255]
+            [0, 0, 0],       # Black
+            [255, 0, 0],     # Red
+            [255, 255, 0],   # Yellow
+            [0, 0, 255],     # Blue
+            [0, 255, 0],     # Green
+            [255, 255, 255]  # White
         ]
-        
-        default_effect = Effect(effect_id=0)
+
+        default_segment = Segment(
+            segment_id=0,
+            color=[0, 1, 2, 3, 4, 5],
+            transparency=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            length=[10, 10, 10, 10, 10],
+            move_speed=100.0,
+            move_range=[0, led_count],
+            initial_position=0,
+            current_position=0.0,
+            is_edge_reflect=True,
+            dimmer_time=[[1000, 0, 100], [1000, 100, 0]]
+        )
+
+        default_effect = Effect(effect_id=0, segments={"0": default_segment})
         
         scene = Scene(
             scene_id=new_id,
@@ -589,6 +606,16 @@ class DataCacheService:
         
         if segment:
             try:
+                if param == "segment_id":
+                    new_id = int(value)
+                    effect = self.get_effect(scene_id, effect_id)
+                    if effect and str(new_id) not in effect.segments:
+                        effect.segments[str(new_id)] = effect.segments.pop(segment_id)
+                        segment.segment_id = new_id
+                        self._notify_change()
+                        return True
+                    return False
+
                 if param == "color":
                     if isinstance(value, dict) and "index" in value and "color_index" in value:
                         index = value["index"]
@@ -667,11 +694,15 @@ class DataCacheService:
         
         if scene and palette_id != self.current_palette_id and 0 <= palette_id < len(scene.palettes):
             del scene.palettes[palette_id]
-            
+
             if self.current_palette_id > palette_id:
                 self.current_palette_id -= 1
                 scene.current_palette_id = self.current_palette_id
-                
+
+            for effect in scene.effects:
+                for segment in effect.segments.values():
+                    segment.color = [0] * len(segment.color)
+
             self._notify_change()
             return True
         return False

--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from services.data_cache import DataCacheService
+
+
+def test_update_segment_id_preserves_data():
+    dc = DataCacheService()
+    original = dc.get_segment("0")
+    original.color[0] = 5
+    assert dc.update_segment_parameter("0", "segment_id", 5)
+    assert dc.get_segment("0") is None
+    updated = dc.get_segment("5")
+    assert updated is not None
+    assert updated.color[0] == 5
+
+
+def test_create_new_scene_has_default_palette_and_segment():
+    dc = DataCacheService()
+    new_scene_id = dc.create_new_scene(led_count=100, fps=60)
+    scene = dc.get_scene(new_scene_id)
+    assert scene.palettes[0] == [[0,0,0],[255,0,0],[255,255,0],[0,0,255],[0,255,0],[255,255,255]]
+    effect = scene.get_effect(0)
+    segment = effect.get_segment("0")
+    assert segment.color == [0,1,2,3,4,5]
+
+
+def test_delete_palette_resets_segment_colors():
+    dc = DataCacheService()
+    seg = dc.get_segment("0")
+    seg.color = [1,2,3,4,5,0]
+    palette_id = dc.create_new_palette()
+    assert palette_id == 1
+    assert dc.delete_palette(palette_id)
+    assert seg.color == [0]*6


### PR DESCRIPTION
## Summary
- preserve segment data when changing segment IDs
- create scenes with default palette and segment for accurate colors
- clear segment color references when palettes are removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3ac1e4e8832a8ddb94818c578394