### PR TITLE
Persist move and region settings per segment

### DIFF
--- a/src/components/color/color_palette.py
+++ b/src/components/color/color_palette.py
@@ -35,8 +35,8 @@ class ColorPaletteComponent(ft.Container):
         
         palette_buttons = CommonBtn().get_buttons(
             ("Add Palette", self._on_add_palette),
-            ("Delete Palette", self.action_handler.delete_palette),
-            ("Copy Palette", self.action_handler.copy_palette)
+            ("Delete Palette", self._on_delete_palette),
+            ("Copy Palette", self._on_copy_palette)
         )
         
         self.color_container = ft.Container(
@@ -103,9 +103,8 @@ class ColorPaletteComponent(ft.Container):
             animate=ft.Animation(200, ft.AnimationCurve.EASE_OUT)
         )
 
-    def _on_add_palette(self, e):
-        """Add palette and refresh dropdown"""
-        self.action_handler.add_palette(e)
+    def _refresh_palette_dropdown(self):
+        """Refresh dropdown options and selection from cache"""
         try:
             palette_ids = data_cache.get_palette_ids()
             self.update_palette_list(palette_ids)
@@ -115,6 +114,21 @@ class ColorPaletteComponent(ft.Container):
                 safe_component_update(self.palette_dropdown, "palette_dropdown_refresh")
         except Exception:
             pass
+
+    def _on_add_palette(self, e):
+        """Add palette and refresh dropdown"""
+        self.action_handler.add_palette(e)
+        self._refresh_palette_dropdown()
+
+    def _on_delete_palette(self, e):
+        """Delete palette and refresh dropdown"""
+        self.action_handler.delete_palette(e)
+        self._refresh_palette_dropdown()
+
+    def _on_copy_palette(self, e):
+        """Copy palette and refresh dropdown"""
+        self.action_handler.copy_palette(e)
+        self._refresh_palette_dropdown()
         
     def _on_palette_change(self, e):
         """Handle palette dropdown change"""

--- a/src/components/data/data_action_handler.py
+++ b/src/components/data/data_action_handler.py
@@ -104,17 +104,19 @@ class DataActionHandler:
                 
             if hasattr(self.scene_effect_panel, 'update_effects_list'):
                 self.scene_effect_panel.update_effects_list(effect_ids)
-                
+
             if hasattr(self.scene_effect_panel, 'update_regions_list'):
                 self.scene_effect_panel.update_regions_list(region_ids)
-                
-            self._update_scene_settings()
-            
-            self._update_scene_selection()
-            
+
             if hasattr(self.scene_effect_panel, 'color_palette'):
-                colors = data_cache.get_current_palette_colors()
-                
+                cp = self.scene_effect_panel.color_palette
+                if hasattr(cp, 'update_palette_list'):
+                    cp.update_palette_list(palette_ids)
+
+            self._update_scene_settings()
+
+            self._update_scene_selection()
+
             safe_component_update(self.scene_effect_panel, "scene_effect_panel_update")
                 
         except Exception as e:
@@ -209,9 +211,13 @@ class DataActionHandler:
                 segment = data_cache.get_segment(selected_id)
 
                 if segment and hasattr(self.segment_edit_panel, 'segment_component'):
-                    if hasattr(self.segment_edit_panel.segment_component, 'segment_dropdown'):
-                        self.segment_edit_panel.segment_component.segment_dropdown.value = selected_id
-                        self.segment_edit_panel.segment_component.segment_dropdown.update()
+                    sc = self.segment_edit_panel.segment_component
+                    if hasattr(sc, 'segment_dropdown'):
+                        sc.segment_dropdown.value = selected_id
+                        sc.segment_dropdown.update()
+                    if hasattr(sc, 'region_assign_dropdown'):
+                        sc.region_assign_dropdown.value = str(getattr(segment, 'region_id', 0))
+                        sc.region_assign_dropdown.update()
 
                 # Ensure color service knows about current segment for proper updates
                 color_service.set_current_segment_id(selected_id)
@@ -230,6 +236,9 @@ class DataActionHandler:
                     if hasattr(sc, 'segment_dropdown'):
                         sc.segment_dropdown.value = None
                         sc.segment_dropdown.update()
+                    if hasattr(sc, 'region_assign_dropdown'):
+                        sc.region_assign_dropdown.value = None
+                        sc.region_assign_dropdown.update()
 
                 self._update_move_component(None)
                 self._update_dimmer_component(None)

--- a/src/components/move/move_action.py
+++ b/src/components/move/move_action.py
@@ -1,5 +1,7 @@
 import flet as ft
 from ..ui.toast import ToastManager
+from services.color_service import color_service
+from services.data_cache import data_cache
 
 
 class MoveActionHandler:
@@ -12,7 +14,14 @@ class MoveActionHandler:
     def update_move_range(self, start: str, end: str):
         """Handle move range update"""
         if self._validate_move_range(start, end):
-            self.toast_manager.show_info_sync(f"Move range updated: {start}-{end}")
+            segment_id = color_service.current_segment_id
+            if segment_id is None:
+                self.toast_manager.show_warning_sync("No segment selected")
+                return False
+            start_val = int(start) if start else 0
+            end_val = int(end) if end else 0
+            data_cache.update_segment_parameter(segment_id, "move_range", [start_val, end_val])
+            self.toast_manager.show_info_sync(f"Move range updated: {start_val}-{end_val}")
             return True
         return False
 
@@ -27,6 +36,11 @@ class MoveActionHandler:
             return False
 
         if self._validate_move_speed(speed_val):
+            segment_id = color_service.current_segment_id
+            if segment_id is None:
+                self.toast_manager.show_warning_sync("No segment selected")
+                return False
+            data_cache.update_segment_parameter(segment_id, "move_speed", speed_val)
             self.toast_manager.show_info_sync(
                 f"Move speed updated: {speed_val:.1f}"
             )
@@ -36,12 +50,21 @@ class MoveActionHandler:
     def update_initial_position(self, position: str):
         """Handle initial position update"""
         if self._validate_initial_position(position):
-            self.toast_manager.show_info_sync(f"Initial position updated: {position}")
+            segment_id = color_service.current_segment_id
+            if segment_id is None:
+                self.toast_manager.show_warning_sync("No segment selected")
+                return False
+            pos_val = int(position) if position else 0
+            data_cache.update_segment_parameter(segment_id, "initial_position", pos_val)
+            self.toast_manager.show_info_sync(f"Initial position updated: {pos_val}")
             return True
         return False
 
-    def update_edge_reflect(self, mode: str):
+    def update_edge_reflect(self, mode: bool):
         """Handle edge reflect mode update"""
+        segment_id = color_service.current_segment_id
+        if segment_id is not None:
+            data_cache.update_segment_parameter(segment_id, "edge_reflect", bool(mode))
         self.toast_manager.show_info_sync(f"Edge reflect mode: {mode}")
 
     def _validate_move_range(self, start: str, end: str):

--- a/src/components/segment/segment_action.py
+++ b/src/components/segment/segment_action.py
@@ -122,7 +122,14 @@ class SegmentActionHandler:
         
     def assign_region_to_segment(self, segment_id: str, region_id: str):
         """Handle region assignment to segment"""
-        self.toast_manager.show_info_sync(f"Segment {segment_id} assigned to Region {region_id}")
+        try:
+            success = data_cache.update_segment_parameter(segment_id, "region_id", int(region_id))
+            if success:
+                self.toast_manager.show_info_sync(f"Segment {segment_id} assigned to Region {region_id}")
+            else:
+                self.toast_manager.show_error_sync(f"Failed to assign Region {region_id} to Segment {segment_id}")
+        except Exception as ex:
+            self.toast_manager.show_error_sync(f"Failed to assign region: {str(ex)}")
         
     def duplicate_segment(self, source_id: str):
         """Duplicate existing segment"""

--- a/src/models/segment.py
+++ b/src/models/segment.py
@@ -15,6 +15,7 @@ class Segment:
     initial_position: int
     current_position: float
     is_edge_reflect: bool
+    region_id: int
     dimmer_time: List[List[int]]
     
     def __post_init__(self):
@@ -25,6 +26,8 @@ class Segment:
             raise ValueError("Move range must contain exactly 2 values")
         if self.move_range[1] < self.move_range[0]:
             raise ValueError("Move range end must be >= start")
+        if self.region_id < 0:
+            raise ValueError("Region ID must be non-negative")
         
         if len(self.color) != len(self.transparency):
             target_size = len(self.color)
@@ -53,6 +56,7 @@ class Segment:
             initial_position=data['initial_position'],
             current_position=data['current_position'],
             is_edge_reflect=data['is_edge_reflect'],
+            region_id=data.get('region_id', 0),
             dimmer_time=data['dimmer_time']
         )
         
@@ -68,6 +72,7 @@ class Segment:
             'initial_position': self.initial_position,
             'current_position': self.current_position,
             'is_edge_reflect': self.is_edge_reflect,
+            'region_id': self.region_id,
             'dimmer_time': self.dimmer_time
         }
         

--- a/src/services/data_cache.py
+++ b/src/services/data_cache.py
@@ -36,6 +36,7 @@ class DataCacheService:
                 "initial_position": 0,
                 "current_position": 0.0,
                 "is_edge_reflect": True,
+                "region_id": 0,
                 "dimmer_time": [
                     [1000, 0, 100],
                     [1000, 100, 0]
@@ -50,12 +51,12 @@ class DataCacheService:
             }
             
             initial_palette = [
-                [0, 0, 0],       # Black
-                [255, 0, 0],     # Red  
+                [255, 0, 0],     # Red
                 [255, 255, 0],   # Yellow
                 [0, 0, 255],     # Blue
                 [0, 255, 0],     # Green
-                [255, 255, 255]  # White
+                [255, 255, 255], # White
+                [0, 0, 0]        # Black
             ]
             
             initial_scene_data = {
@@ -177,6 +178,9 @@ class DataCacheService:
                 else:
                     length = length[:expected_length_count]
                 segment_data['length'] = length
+
+            if 'region_id' not in segment_data:
+                segment_data['region_id'] = 0
                 
             AppLogger.info(f"Fixed segment {segment_data.get('segment_id')}: colors={color_count}, transparency={len(transparency)}, length={len(length)}")
             
@@ -411,12 +415,12 @@ class DataCacheService:
         new_id = max(self.scenes.keys()) + 1 if self.scenes else 0
         
         default_palette = [
-            [0, 0, 0],       # Black
             [255, 0, 0],     # Red
             [255, 255, 0],   # Yellow
             [0, 0, 255],     # Blue
             [0, 255, 0],     # Green
-            [255, 255, 255]  # White
+            [255, 255, 255], # White
+            [0, 0, 0]        # Black
         ]
 
         default_segment = Segment(
@@ -429,6 +433,7 @@ class DataCacheService:
             initial_position=0,
             current_position=0.0,
             is_edge_reflect=True,
+            region_id=0,
             dimmer_time=[[1000, 0, 100], [1000, 100, 0]]
         )
 
@@ -561,6 +566,7 @@ class DataCacheService:
                 initial_position=0,
                 current_position=0.0,
                 is_edge_reflect=True,
+                region_id=0,
                 dimmer_time=[[1000, 0, 100], [1000, 100, 0]]
             )
 
@@ -652,6 +658,8 @@ class DataCacheService:
                     segment.initial_position = int(value)
                 elif param == "edge_reflect":
                     segment.is_edge_reflect = bool(value)
+                elif param == "region_id":
+                    segment.region_id = int(value)
                 elif param == "solo":
                     segment.is_solo = bool(value)
                 elif param == "mute":

--- a/src/services/file_service.py
+++ b/src/services/file_service.py
@@ -19,6 +19,13 @@ class FileService:
         self.on_error: Optional[Callable] = None
         self.on_file_open_requested: Optional[Callable] = None
         self.on_file_save_as_requested: Optional[Callable] = None
+
+        if self.data_cache:
+            self.data_cache.add_change_listener(self._on_data_cache_change)
+
+    def _on_data_cache_change(self):
+        """Mark file as dirty when underlying cache changes"""
+        self.mark_as_changed()
         
     def request_file_open(self):
         """Request file open dialog - should be handled by UI layer"""

--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -22,7 +22,7 @@ def test_create_new_scene_has_default_palette_and_segment():
     dc = DataCacheService()
     new_scene_id = dc.create_new_scene(led_count=100, fps=60)
     scene = dc.get_scene(new_scene_id)
-    assert scene.palettes[0] == [[0,0,0],[255,0,0],[255,255,0],[0,0,255],[0,255,0],[255,255,255]]
+    assert scene.palettes[0] == [[255,0,0],[255,255,0],[0,0,255],[0,255,0],[255,255,255],[0,0,0]]
     effect = scene.get_effect(0)
     segment = effect.get_segment("0")
     assert segment.color == [0,1,2,3,4,5]
@@ -36,3 +36,18 @@ def test_delete_palette_resets_segment_colors():
     assert palette_id == 1
     assert dc.delete_palette(palette_id)
     assert seg.color == [0,1,2,3,4,5]
+
+
+def test_load_json_defaults_missing_region_id_to_zero():
+    dc = DataCacheService()
+    data = dc.export_to_dict()
+    seg_dict = data['scenes'][0]['effects'][0]['segments']['0']
+    del seg_dict['region_id']
+
+    new_dc = DataCacheService()
+    assert new_dc.load_from_json_data(data)
+    seg = new_dc.get_segment("0")
+    assert seg.region_id == 0
+
+    exported = new_dc.export_to_dict()
+    assert exported['scenes'][0]['effects'][0]['segments']['0']['region_id'] == 0

--- a/tests/test_file_service.py
+++ b/tests/test_file_service.py
@@ -1,0 +1,39 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from services.file_service import FileService
+from services.data_cache import DataCacheService
+
+
+def test_save_to_path_writes_model_format(tmp_path):
+    dc = DataCacheService()
+    fs = FileService(dc)
+    target = tmp_path / "scene_save_as.json"
+    assert fs.save_to_path(str(target))
+    with open(target, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data == dc.export_to_dict()
+
+
+def test_save_file_uses_current_path(tmp_path):
+    dc = DataCacheService()
+    fs = FileService(dc)
+    fs.current_file_path = str(tmp_path / "scene_save.json")
+    dc.update_scene_settings(0, 300, None)
+    assert fs.has_unsaved_changes()
+    assert fs.save_file()
+    assert not fs.has_unsaved_changes()
+    with open(fs.current_file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data == dc.export_to_dict()
+
+
+def test_data_change_marks_dirty():
+    dc = DataCacheService()
+    fs = FileService(dc)
+    assert not fs.has_unsaved_changes()
+    dc.update_scene_settings(0, 300, None)
+    assert fs.has_unsaved_changes()

--- a/tests/test_move_action.py
+++ b/tests/test_move_action.py
@@ -4,11 +4,17 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from components.move.move_action import MoveActionHandler
+from services.color_service import color_service
+from services.data_cache import data_cache
 
 
-def test_update_move_speed_accepts_string_and_validates():
+def test_update_move_speed_updates_cache_and_validates():
     handler = MoveActionHandler(page=None)
+    data_cache.set_current_scene(0)
+    color_service.set_current_segment_id("0")
+
     assert handler.update_move_speed("5")
+    assert data_cache.get_segment("0").move_speed == 5.0
     assert not handler.update_move_speed("-1")
     assert not handler.update_move_speed("abc")
 

--- a/tests/test_palette_dropdown_load.py
+++ b/tests/test_palette_dropdown_load.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+import sys
+import flet as ft
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from components.data.data_action_handler import DataActionHandler
+from services.data_cache import data_cache
+
+class DummyPage:
+    def __init__(self):
+        self.overlay = None
+    def run_task(self, coro):
+        asyncio.run(coro)
+
+class DummyPaletteComponent:
+    def __init__(self):
+        self.palette_dropdown = ft.Dropdown(options=[ft.dropdown.Option("0")], value="0")
+    def update_palette_list(self, palette_ids):
+        self.palette_dropdown.options = [ft.dropdown.Option(str(i)) for i in palette_ids]
+
+class DummySceneEffectPanel:
+    def __init__(self):
+        self.color_palette = DummyPaletteComponent()
+    def update_scenes_list(self, _):
+        pass
+    def update_effects_list(self, _):
+        pass
+    def update_regions_list(self, _):
+        pass
+
+
+def test_palette_dropdown_updated_on_load():
+    data_cache.clear()
+    json_data = data_cache.export_to_dict()
+    scene = json_data['scenes'][0]
+    scene['palettes'].append(scene['palettes'][0])
+    scene['current_palette_id'] = 1
+    json_data['current_palette_id'] = 1
+
+    page = DummyPage()
+    handler = DataActionHandler(page)
+    panel = DummySceneEffectPanel()
+    handler.scene_effect_panel = panel
+
+    assert handler.load_json_data(json_data)
+    assert len(panel.color_palette.palette_dropdown.options) == 2
+    assert panel.color_palette.palette_dropdown.value == "1"
+    data_cache.clear()

--- a/tests/test_segment_persistence.py
+++ b/tests/test_segment_persistence.py
@@ -4,6 +4,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from components.panel.segment_edit_action import SegmentEditActionHandler
+from components.move.move_action import MoveActionHandler
+from components.segment.segment_action import SegmentActionHandler
 from services.color_service import color_service
 from services.data_cache import data_cache
 
@@ -18,6 +20,8 @@ class StubSegmentComponent:
 
 def test_segment_updates_persist_across_switch():
     handler = SegmentEditActionHandler(page=None)
+    move_handler = MoveActionHandler(page=None)
+    segment_handler = SegmentActionHandler(page=None)
 
     # Reset to initial scene with default segment
     data_cache.set_current_scene(0)
@@ -31,6 +35,11 @@ def test_segment_updates_persist_across_switch():
     handler.update_segment_color_slot("0", 0, 3)
     handler.update_transparency_from_slider(0, 0.5, StubSegmentComponent("0"))
     handler.update_length_parameter(0, "20", StubSegmentComponent("0"))
+    move_handler.update_move_range("10", "50")
+    move_handler.update_move_speed("5")
+    move_handler.update_initial_position("20")
+    move_handler.update_edge_reflect(False)
+    segment_handler.assign_region_to_segment("0", "2")
 
     # Switch to another segment then back
     color_service.set_current_segment_id("1")
@@ -40,3 +49,8 @@ def test_segment_updates_persist_across_switch():
     assert seg0.color[0] == 3
     assert seg0.transparency[0] == 0.5
     assert seg0.length[0] == 20
+    assert seg0.move_range == [10, 50]
+    assert seg0.move_speed == 5.0
+    assert seg0.initial_position == 20
+    assert seg0.is_edge_reflect is False
+    assert seg0.region_id == 2


### PR DESCRIPTION
## Summary
- persist move range, speed, initial position and edge reflect in cache for selected segment
- store and restore region assignment for each segment
- standardize default palette ordering
- default missing segment `region_id` to 0 when loading JSON data and re-export
- refresh palette dropdown after creating, duplicating or deleting palettes
- add tests verifying JSON export via save and save-as paths
- track data cache changes to mark files dirty so Save overwrites the current file
- populate palette dropdown with loaded palettes immediately after importing JSON

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4963deac832a8012741535d69c35