### PR TITLE
Enable editing for newly added color slots

### DIFF
--- a/src/services/data_cache.py
+++ b/src/services/data_cache.py
@@ -174,7 +174,7 @@ class DataCacheService:
             expected_length_count = max(0, color_count - 1)
             if len(length) != expected_length_count:
                 if len(length) < expected_length_count:
-                    length.extend([0] * (expected_length_count - len(length)))
+                    length.extend([10] * (expected_length_count - len(length)))
                 else:
                     length = length[:expected_length_count]
                 segment_data['length'] = length
@@ -626,25 +626,46 @@ class DataCacheService:
                     if isinstance(value, dict) and "index" in value and "color_index" in value:
                         index = value["index"]
                         color_index = value["color_index"]
-                        if 0 <= index < len(segment.color):
+                        if index >= 0:
+                            if index >= len(segment.color):
+                                segment.color.extend([0] * (index + 1 - len(segment.color)))
+                                if index >= len(segment.transparency):
+                                    segment.transparency.extend([1.0] * (index + 1 - len(segment.transparency)))
+                                expected_len = len(segment.color) - 1
+                                if len(segment.length) < expected_len:
+                                    segment.length.extend([10] * (expected_len - len(segment.length)))
                             segment.color[index] = color_index
                     elif isinstance(value, list):
                         segment.color = value
-                        
+
                 elif param == "transparency":
                     if isinstance(value, dict) and "index" in value and "transparency" in value:
                         index = value["index"]
                         transparency = value["transparency"]
-                        if 0 <= index < len(segment.transparency):
+                        if index >= 0:
+                            if index >= len(segment.transparency):
+                                segment.transparency.extend([1.0] * (index + 1 - len(segment.transparency)))
+                            if index >= len(segment.color):
+                                segment.color.extend([0] * (index + 1 - len(segment.color)))
+                            expected_len = len(segment.color) - 1
+                            if len(segment.length) < expected_len:
+                                segment.length.extend([10] * (expected_len - len(segment.length)))
                             segment.transparency[index] = transparency
                     elif isinstance(value, list):
                         segment.transparency = value
-                        
+
                 elif param == "length":
                     if isinstance(value, dict) and "index" in value and "length" in value:
                         index = value["index"]
                         length = value["length"]
-                        if 0 <= index < len(segment.length):
+                        if index >= 0:
+                            if index >= len(segment.length):
+                                segment.length.extend([10] * (index + 1 - len(segment.length)))
+                            required_colors = index + 2
+                            if len(segment.color) < required_colors:
+                                add = required_colors - len(segment.color)
+                                segment.color.extend([0] * add)
+                                segment.transparency.extend([1.0] * add)
                             segment.length[index] = length
                     elif isinstance(value, list):
                         segment.length = value

--- a/tests/test_extend_segment_arrays.py
+++ b/tests/test_extend_segment_arrays.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import sys
+
+
+# Ensure src modules can be imported
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from components.panel.segment_edit_action import SegmentEditActionHandler
+from services.color_service import color_service
+from services.data_cache import data_cache
+
+
+class StubSegmentComponent:
+    def __init__(self, segment_id: str):
+        self._segment_id = segment_id
+
+    def get_selected_segment(self):
+        return self._segment_id
+
+
+def test_extend_segment_arrays_allows_editing_new_slots():
+    handler = SegmentEditActionHandler(page=None)
+    segment_component = StubSegmentComponent("0")
+
+    data_cache.set_current_scene(0)
+    color_service.sync_with_cache_palette()
+    color_service.set_current_segment_id("0")
+
+    seg0 = data_cache.get_segment("0")
+    seg0.color = [0, 1]
+    seg0.transparency = [1.0, 1.0]
+    seg0.length = [10]
+
+    handler.update_segment_color_slot("0", 2, 3)
+
+    seg0 = data_cache.get_segment("0")
+    assert seg0.color[2] == 3
+    assert seg0.transparency[2] == 1.0
+    assert len(seg0.length) == 2
+    assert seg0.length[1] == 10
+
+    handler.update_transparency_from_slider(2, 0.4, segment_component)
+    seg0 = data_cache.get_segment("0")
+    assert seg0.transparency[2] == 0.4
+
+    handler.update_length_parameter(2, "30", segment_component)
+    seg0 = data_cache.get_segment("0")
+    assert seg0.length[2] == 30
+    assert len(seg0.color) >= 4
+

--- a/tests/test_segment_edit_panel_disable.py
+++ b/tests/test_segment_edit_panel_disable.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from components.panel.segment_edit_panel import SegmentEditPanel
+from services.data_cache import data_cache
+from services.color_service import color_service
+
+class DummyPage:
+    def __init__(self):
+        self.overlay = []
+        self.theme = None
+        self.width = 0
+    def update(self):
+        pass
+    def run_task(self, coro):
+        pass
+    def open(self, modal):
+        pass
+
+def setup_segment_two_colors():
+    segment = data_cache.get_segment('0')
+    segment.color = [0, 1]
+    segment.transparency = [0.0, 0.5]
+    segment.length = [50]
+    color_service.set_current_segment_id('0')
+
+
+def test_fields_disabled_for_unused_slots():
+    setup_segment_two_colors()
+    page = DummyPage()
+    panel = SegmentEditPanel(page)
+    panel.update_color_composition()
+    assert panel.transparency_fields[2].disabled
+    assert panel.transparency_sliders[2].disabled
+    assert panel.length_fields[1].disabled
+
+
+def test_fields_enabled_after_adding_color():
+    setup_segment_two_colors()
+    page = DummyPage()
+    panel = SegmentEditPanel(page)
+    for ctrl in panel.transparency_fields + panel.transparency_sliders + panel.length_fields:
+        ctrl.update = lambda *args, **kwargs: None
+
+    segment = data_cache.get_segment('0')
+    segment.color.append(2)
+    segment.transparency.append(0.7)
+    segment.length.append(60)
+
+    panel.update_transparency_values()
+    panel.update_length_values()
+    assert not panel.transparency_fields[2].disabled
+    assert not panel.transparency_sliders[2].disabled
+    assert not panel.length_fields[1].disabled


### PR DESCRIPTION
## Summary
- allow `update_segment_parameter` to expand color, transparency, and length arrays when updating out-of-range indexes
- disable transparency sliders and length fields for unused color slots and enable when colors are added
- use a positive default length when arrays are extended to avoid validation errors
- cover extending and UI enabling behavior with tests

## Testing
- `pip install -r requirements.txt`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac91a367e0832aa49d23ed5258ae3c