### PR TITLE
Ensure segment lengths are positive and align with color/transparency

### DIFF
--- a/src/models/segment.py
+++ b/src/models/segment.py
@@ -36,12 +36,16 @@ class Segment:
             elif len(self.transparency) > target_size:
                 self.transparency = self.transparency[:target_size]
         
-        expected_length_size = len(self.color) - 1
+        # Ensure length array size matches color/transparency count minus one
+        expected_length_size = max(0, max(len(self.color), len(self.transparency)) - 1)
         if len(self.length) != expected_length_size:
             if len(self.length) < expected_length_size:
                 self.length.extend([10] * (expected_length_size - len(self.length)))
             elif len(self.length) > expected_length_size:
                 self.length = self.length[:expected_length_size]
+
+        # All length values must be positive
+        self.length = [value if value > 0 else 10 for value in self.length]
             
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'Segment':

--- a/src/services/data_cache.py
+++ b/src/services/data_cache.py
@@ -171,13 +171,16 @@ class DataCacheService:
                     transparency = transparency[:color_count]
                 segment_data['transparency'] = transparency
                 
-            expected_length_count = max(0, color_count - 1)
+            expected_length_count = max(0, max(color_count, len(transparency)) - 1)
             if len(length) != expected_length_count:
                 if len(length) < expected_length_count:
                     length.extend([10] * (expected_length_count - len(length)))
                 else:
                     length = length[:expected_length_count]
                 segment_data['length'] = length
+
+            # Replace non-positive lengths with default value
+            segment_data['length'] = [val if val > 0 else 10 for val in segment_data['length']]
 
             if 'region_id' not in segment_data:
                 segment_data['region_id'] = 0

--- a/tests/test_segment_length_validation.py
+++ b/tests/test_segment_length_validation.py
@@ -1,0 +1,39 @@
+from src.models.segment import Segment
+from src.services.data_cache import data_cache
+
+
+def test_segment_init_fixes_length_size_and_positivity():
+    seg = Segment(
+        segment_id=1,
+        color=[1, 2, 3],
+        transparency=[1.0],
+        length=[-5, 0, 20],
+        move_speed=0.0,
+        move_range=[0, 10],
+        initial_position=0,
+        current_position=0.0,
+        is_edge_reflect=False,
+        region_id=0,
+        dimmer_time=[],
+    )
+
+    # Transparency is extended to match color count
+    assert seg.transparency == [1.0, 1.0, 1.0]
+    # Length list is resized to color count minus one and all values are positive
+    assert seg.length == [10, 10]
+
+
+def test_fix_segment_arrays_enforces_positive_length():
+    segment_data = {
+        "segment_id": 0,
+        "color": [1, 2],
+        "transparency": [1.0],
+        "length": [0, -5],
+    }
+
+    data_cache._fix_segment_arrays(segment_data)
+
+    # Transparency is extended to match color count
+    assert segment_data["transparency"] == [1.0, 1.0]
+    # Length is resized to color/transparency count minus one and values are positive
+    assert segment_data["length"] == [10]


### PR DESCRIPTION
## Summary
- enforce non-negative length array sizing based on color/transparency counts
- sanitize segment length values to default positive amounts during init and cache fixes
- add regression tests for segment length validation

## Testing
- `PYTHONPATH=$PWD pytest tests -q --import-mode=importlib`

------
https://chatgpt.com/codex/tasks/task_e_68ac97eaaf2c832ab7c29854aeefb7ed